### PR TITLE
feature(get-withPending-status): implement get loans that have pending

### DIFF
--- a/SERVER/spec/loan.js
+++ b/SERVER/spec/loan.js
@@ -188,10 +188,12 @@ describe('QUICK-CREDIT Test Suite', () => {
         .set('Accept', 'application/json')
         .set({ authorization: `${token}` })
         .end((err, res) => {
+          const userLoan = res.body.data.find(loan => loan.client === 'john.wilson@yahoo.com');
           expect(res.status).to.equal(200);
-          expect(res.body.data[0].repaid).to.equal(false);
-          expect(res.body.data[0].status).to.equal('pending');
-          expect(res.body.data[0].user).to.equal('levy.right@yahoo.com');
+          expect(userLoan.repaid).to.equal(false);
+          expect(userLoan.status).to.equal('pending');
+          expect(userLoan.client).to.equal('john.wilson@yahoo.com');
+          expect(res.body.data.length).to.equal(3);
           done();
         });
     });

--- a/SERVER/src/controller/loan.js
+++ b/SERVER/src/controller/loan.js
@@ -34,8 +34,8 @@ class Loan {
     const loans = [...data.loans];
     const { status, repaid } = req.query;
     if (status === 'pending') {
-      const pendingLoans = loanHelpers.getPendingLoans(loans);
-      res.status(200).json({ status: 200, data: pendingLoans }).end();
+      const pendingLoans = await loanHelpers.getPendingLoans({ status, repaid });
+      res.status(200).json({ status: 200, data: pendingLoans.data }).end();
     } else if (status === 'approved' && !JSON.parse(repaid)) {
       const notRepaidLoans = await loanHelpers.getNotRepaidLoans({ status, repaid });
       res.status(200).json({ status: 200, data: notRepaidLoans.data }).end();

--- a/SERVER/src/helpers/loan.js
+++ b/SERVER/src/helpers/loan.js
@@ -57,13 +57,8 @@ class LoanHelpers {
     return notFullyRepaidLoans;
   }
 
-  static getPendingLoans(loans) {
-    const approvedLoans = [];
-    loans.forEach((loan) => {
-      if (loan.status === 'pending') {
-        approvedLoans.push(loan);
-      }
-    });
+  static async getPendingLoans({ status, repaid }) {
+    const approvedLoans = await readRecs('loans', { status, repaid });
     return approvedLoans;
   }
 


### PR DESCRIPTION
#### What does this PR do?
Have an admin user get loans that have a pending status
#### Description of Task to be completed?

- Reuse readRecs function
- Modify getPendingLoans helper
- Modify getAllLoans method

#### How should this be manually tested?

- clone the project https://github.com/Pomile/Quick-Credit.git
- cd into the project root directory
- enter` npm install`
- enter `npm test`

#### What are the relevant pivotal tracker stories?
#166109017
#### Any background context you want to add?
Nil
#### Screenshots
![getloan-pending-post-db](https://user-images.githubusercontent.com/28379439/58001470-79b36980-7ad3-11e9-9759-5f25cef88306.JPG)
