### PR TITLE
#166347906  An admin user should be able to get either verified or unverified users with address and loan requested

### DIFF
--- a/SERVER/spec/loan.js
+++ b/SERVER/spec/loan.js
@@ -265,5 +265,17 @@ describe('QUICK-CREDIT Test Suite', () => {
           done();
         });
     });
+    it('should allow an admin user to get users by status who has also applied for a loan', (done) => {
+      const { token } = userData.adminAuth;
+      request(app)
+        .get('/api/v1/users?status=unverified')
+        .set('Accept', 'application/json')
+        .set({ authorization: `${token}` })
+        .end((err, res) => {
+          expect(res.status).to.equal(200);
+          expect(res.body.data.length).to.equal(0);
+          done();
+        });
+    });
   });
 });

--- a/SERVER/spec/user.js
+++ b/SERVER/spec/user.js
@@ -505,7 +505,6 @@ describe('QUICK-CREDIT Test Suite', () => {
           done();
         });
     });
-
     it('should allow an admin user to verify a user', (done) => {
       const { token } = userData.adminAuth;
       request(app)

--- a/SERVER/src/controller/user.js
+++ b/SERVER/src/controller/user.js
@@ -104,6 +104,19 @@ class User {
     }
   }
 
+  static async getUsersbyStatus(req, res) {
+    const { status } = req.query;
+    const matches = {
+      users: ['id', 'email', 'status'],
+      addresses: ['userid', 'homeaddress', 'state'],
+      loans: ['client', 'amount', 'tenor', 'repaid', 'interest'],
+    };
+    const usersLoanDetails = await userHelpers.getUsersByStatus(matches, { status, repaid: false });
+    if (usersLoanDetails.data) {
+      responseHelper.oK(res, usersLoanDetails.data);
+    }
+  }
+
   static async modifyUserAdminPriviledge(req, res) {
     const { email } = req.params;
     const { isadmin } = req.body;

--- a/SERVER/src/helpers/crud/readWithInnerJoin.js
+++ b/SERVER/src/helpers/crud/readWithInnerJoin.js
@@ -1,0 +1,56 @@
+import debug from 'debug';
+import db from '../../models/index';
+
+const { pool } = db;
+
+const parameters = (matches, filters) => {
+  const exprFields = Object.values(matches);
+  const tablenames = Object.keys(matches);
+  const tableTags = tablenames.map(tablename => tablename.slice(0, 1));
+  const filterFields = Object.keys(filters);
+  const values = Object.values(filters);
+  const tablenamesWithTags = tablenames.map(tablename => `${tablename} ${tablename.slice(0, 1)}`);
+  const fieldsWithTags = exprFields.map((fields, index) => fields.map(field => `${tableTags[index]}.${field}`)).map(tagsWithF => tagsWithF.join(', ')).join(', ');
+
+  const JOINS = tablenamesWithTags.map((tablenamesWithTag, index) => {
+    if (index === 1) {
+      return `INNER JOIN ${tablenamesWithTag} 
+              ON ${tableTags[index]}.${exprFields[index][0]} =${tableTags[0]}.${exprFields[0][0]}`;
+    }
+    if (index === 2) {
+      return `INNER JOIN ${tablenamesWithTag} 
+                ON ${tableTags[index]}.${exprFields[index][0]} =${tableTags[0]}.${exprFields[0][1]}`;
+    }
+    return '';
+  });
+  const nodPgVars = filterFields.map((field, i) => `${field}=$${1 + i}`);
+  return {
+    tablenames, tableTags, filterFields, values, fieldsWithTags, JOINS, nodPgVars, tablenamesWithTags,
+  };
+};
+
+const readWithInnerJoin = async (matches, filters) => {
+  const params = parameters(matches, filters);
+  const {
+    tableTags, values, fieldsWithTags, JOINS, nodPgVars, tablenamesWithTags,
+  } = params;
+  const client = await pool.connect();
+  const condition = nodPgVars.length === 2 ? (`${tableTags[0]}.${nodPgVars[0]} AND ${tableTags[2]}.${nodPgVars[1]} `) : `${tableTags[0]}.${nodPgVars[0]}`;
+  const queryText = {
+    text: `SELECT ${fieldsWithTags}
+        FROM ${tablenamesWithTags[0]} 
+        ${JOINS.filter(join => join !== '').join(' ')}
+        WHERE ${condition};`,
+    values,
+  };
+  try {
+    const data = await client.query(queryText);
+    return { success: true, data: data.rows };
+  } catch (err) {
+    return { success: false, data: null, msg: err.message };
+  } finally {
+    client.release();
+  }
+};
+
+export default readWithInnerJoin;

--- a/SERVER/src/helpers/user.js
+++ b/SERVER/src/helpers/user.js
@@ -1,6 +1,7 @@
 import read from './crud/read';
 import create from './crud/create';
 import update from './crud/update';
+import readWithInnerJoin from './crud/readWithInnerJoin';
 
 class UserHelpers {
   static async findUser(table, field, value) {
@@ -48,6 +49,11 @@ class UserHelpers {
   static async updateUserStatus({ status }, { email }) {
     const userStatus = await update('users', { status }, { email });
     return userStatus;
+  }
+
+  static async getUsersByStatus(matches, { status, repaid }) {
+    const usersAndLoanDetails = await readWithInnerJoin(matches, { status, repaid });
+    return usersAndLoanDetails;
   }
 
   static async updateUserPriviledge({ isadmin }, { email }) {

--- a/SERVER/src/route/route.js
+++ b/SERVER/src/route/route.js
@@ -43,6 +43,13 @@ routes.post(
   user.createUserJob,
 );
 
+routes.get(
+  '/users',
+  verifyUser,
+  permit,
+  user.getUsersbyStatus,
+);
+
 
 routes.post(
   '/loans',

--- a/SERVER/src/seeder/data/data.js
+++ b/SERVER/src/seeder/data/data.js
@@ -1,11 +1,11 @@
 const data = {
   admin: {
-      firstname: 'admin',
-      lastname: 'super',
-      email: 'admin.super@gmail.com',
-      phone: '09078282176',
-      password: 'admin12345',
-      isadmin: true,
+    firstname: 'admin',
+    lastname: 'super',
+    email: 'admin.super@gmail.com',
+    phone: '09078282176',
+    password: 'admin12345',
+    isadmin: true,
   },
   users: [
     /* {


### PR DESCRIPTION
#### What does this PR do?
Have an admin user get all users who has applied for a loan need to be verify
#### Description of Task to be completed?
-Create a function that reads unverified 
users that has an address and also requested
for a loan
-Create get users by status helper function
-Create get users by status controller method
-Create a route for the controller - get users by status

#### How should this be manually tested?
- clone the project https://github.com/Pomile/Quick-Credit.git
- cd into the project root directory
- enter `npm install`
- enter `npm run local:test`
#### What are the relevant pivotal tracker stories?
#166347906
#### Any background context you want to add?
Nil
#### Screenshots
![getUserByStatus](https://user-images.githubusercontent.com/28379439/58657373-0bae4400-8316-11e9-8c43-b42fe4757ceb.JPG)


